### PR TITLE
Create a errata

### DIFF
--- a/Errata
+++ b/Errata
@@ -1,0 +1,2 @@
+Página 160, há um erro de tradução, teria que ser traduzido da seguinte forma:
+[...]Pelo fato de não serem ordenados, os dicionarios NÂO podem ser fatiados como as listas.[...]


### PR DESCRIPTION
Livro Automatize Tarefas Maçantes com Python
Página 160, há um erro de tradução, teria que ser traduzido da seguinte forma:
[...]Pelo fato de não serem ordenados, os dicionarios NÂO podem ser fatiados como as listas.[...]